### PR TITLE
Update Mflux_Pro.py

### DIFF
--- a/Mflux_Comfy/Mflux_Pro.py
+++ b/Mflux_Comfy/Mflux_Pro.py
@@ -39,7 +39,7 @@ class MfluxImg2Img:
         with Image.open(image_path) as img:
             width, height = img.size
 
-        return MfluxImagePipeline(image_path, image_strength), width, height
+        return MfluxImg2ImgPipeline(image_path, image_strength), width, height
 
     @classmethod
     def IS_CHANGED(cls, image, image_strength):


### PR DESCRIPTION
Corrected an error: the MFluxImg2ImgPipepeline was still called with the old name